### PR TITLE
Fix cost sensor to allow items without cost

### DIFF
--- a/custom_components/mittfortum/sensor.py
+++ b/custom_components/mittfortum/sensor.py
@@ -147,7 +147,7 @@ class FortumCostSensor(CoordinatorEntity, SensorEntity):
         """Return the state of the sensor."""
         data = self.coordinator.data
         if self.coordinator.data:
-            return sum(item["cost"] for item in data)
+            return sum(item["cost"] for item in data if "cost" in item)
         else:
             return None
 


### PR DESCRIPTION
I have become a Fortum customer by their acquisition of Telge Energi. Because of this is my historical costs not complete. The early ones only contains the consumption but no cost. This patch will only sum all costs if they exist and not break on the missing key.